### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "magento/magento-composer-installer": true
+            "magento/*": true
         }
     },
     "repositories": [


### PR DESCRIPTION
```
In PluginManager.php line 762:
                                                                               
  magento/composer-dependency-version-audit-plugin contains a Composer plugin  
   which is blocked by your allow-plugins config. You may add it to the list   
  if you consider it safe.                                                     
  You can run "composer config --no-plugins allow-plugins.magento/composer-de  
  pendency-version-audit-plugin [true|false]" to enable it (true) or disable   
  it explicitly and suppress this exception (false)                            
  See https://getcomposer.org/allow-plugins                                    
                                                                               
install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
The command "composer install --no-interaction" failed and exited with 1 during .

```