### PR TITLE
Add to database logs and earlier framework instantiation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,15 @@ script:
     - php $TRAVIS_BUILD_DIR/dev/prepare_phpunit_config.php $TRAVIS_BUILD_DIR/vendor/ampersand/travis-vanilla-magento/instances/ampmodule
     - composer install -o
     - IS_CI_PIPELINE=1 vendor/bin/phpunit -c $(pwd)/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug
-    # Test di compilation
-    - php bin/magento module:enable --all
-    - php bin/magento setup:di:compile
     # Output the custom loggers command filtering out modules we've accounted for
     - if [[ $TEST_GROUP = magento_23 ]];     then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" ; fi
     - if [[ $TEST_GROUP = magento_latest ]]; then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger" ; fi
+    # Test di compilation
+    - rm -rf generated
+    - composer install
+    - php bin/magento cache:flush
+    - php bin/magento module:enable --all
+    - php bin/magento setup:di:compile
 
 after_failure:
   - cd ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ script:
     - rm -rf generated
     - composer install
     - php bin/magento
-    - php bin/magento cache:flush
     - php bin/magento module:enable --all
     - php bin/magento setup:di:compile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ script:
     # Test di compilation
     - rm -rf generated
     - composer install
+    - php bin/magento
     - php bin/magento cache:flush
     - php bin/magento module:enable --all
     - php bin/magento setup:di:compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ script:
     - php $TRAVIS_BUILD_DIR/dev/prepare_phpunit_config.php $TRAVIS_BUILD_DIR/vendor/ampersand/travis-vanilla-magento/instances/ampmodule
     - composer install -o
     - IS_CI_PIPELINE=1 vendor/bin/phpunit -c $(pwd)/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug
-    # Output the custom loggers command filtering out modules we've accounted for
-    - if [[ $TEST_GROUP = magento_23 ]];     then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" ; fi
-    - if [[ $TEST_GROUP = magento_latest ]]; then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger" ; fi
     # Test di compilation
     - php bin/magento module:enable --all
     - php bin/magento setup:di:compile
+    # Output the custom loggers command filtering out modules we've accounted for
+    - if [[ $TEST_GROUP = magento_23 ]];     then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" ; fi
+    - if [[ $TEST_GROUP = magento_latest ]]; then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger" ; fi
 
 after_failure:
   - cd ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,10 @@ script:
     - php bin/magento setup:di:compile
 
 after_failure:
-    - test -d ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/report/ && for r in ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/report/*; do cat $r; done
-    - test -f ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/log/system.log && grep -v "Broken reference" ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/log/system.log
-    - test -f ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/log/exception.log && cat ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/log/exception.log
-    - test -f ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/log/support_report.log && grep -v "Broken reference" ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/log/support_report.log
-    - sleep 10; 
+  - cd ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/
+  - for r in ./var/report/*; do cat $r; done
+  - for l in ./var/log/*;  do cat $l; done
+  - ls -l ./dev/tests/integration/tmp/sandbox*/var
+  - for r in ./dev/tests/integration/tmp/sandbox*/var/report/*; do cat $r; done
+  - for l in ./dev/tests/integration/tmp/sandbox*/var/log/*; do cat $l; done
+  - sleep 10;

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,6 @@ script:
     # Test di compilation
     - rm -rf generated
     - composer install
-    - php bin/magento
     - php bin/magento module:enable --all
     - php bin/magento setup:di:compile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ script:
     # Output the custom loggers command filtering out modules we've accounted for
     - if [[ $TEST_GROUP = magento_23 ]];     then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" ; fi
     - if [[ $TEST_GROUP = magento_latest ]]; then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger" ; fi
+    # Test di compilation
+    - php bin/magento module:enable --all
+    - php bin/magento setup:di:compile
+
 after_failure:
     - test -d ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/report/ && for r in ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/report/*; do cat $r; done
     - test -f ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/log/system.log && grep -v "Broken reference" ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/var/log/system.log

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This cache decorator initialises the identifier which is immutable for the remai
 - The correlation ID is attached to web responses as `X-Log-Correlation-Id` in `src/HttpResponse/HeaderProvider/LogCorrelationIdHeader.php`
     - REST API requests work a bit differently in Magento and attach the header using `src/Plugin/AddToWebApiResponse.php`
 - Monolog files have the correlation ID added into their context section under the key `amp_correlation_id` via `src/Processor/MonologCorrelationId.php`
+- Magento database logs have this identifier added by `src/Plugin/AddToDatabaseLogs.php`
 - New Relic has this added as a custom parameter under the key `amp_correlation_id`
 
 ## Example usage

--- a/dev/ampersand_magento2_log_correlation/di.xml
+++ b/dev/ampersand_magento2_log_correlation/di.xml
@@ -26,4 +26,16 @@
             <argument name="headerInput" xsi:type="string"></argument>
         </arguments>
     </type>
+    
+    <!-- Attach amp_correlation_id to all framework monolog entries -->
+    <type name="Magento\Framework\Logger\Monolog">
+        <arguments>
+            <argument name="processors" xsi:type="array">
+                <item name="correlationIdProcessor" xsi:type="array">
+                    <item name="0" xsi:type="object">Ampersand\LogCorrelationId\Processor\MonologCorrelationId</item>
+                    <item name="1" xsi:type="string">addCorrelationId</item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/src/Plugin/AddToDatabaseLogs.php
+++ b/src/Plugin/AddToDatabaseLogs.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace Ampersand\LogCorrelationId\Plugin;
 
 use Ampersand\LogCorrelationId\Service\CorrelationIdentifier;
+use Magento\Framework\DB\LoggerInterface;
 
 class AddToDatabaseLogs
 {
@@ -24,11 +25,11 @@ class AddToDatabaseLogs
     /**
      * Append the log correlation ID to the database log
      *
-     * @param $subject
-     * @param $string
+     * @param LoggerInterface $subject
+     * @param string $string
      * @return string
      */
-    public function beforeLog($subject, $string)
+    public function beforeLog(LoggerInterface $subject, $string)
     {
         $logCorrelationIdString =
             $this->correlationIdentifier->getIdentifierKey() .

--- a/src/Plugin/AddToDatabaseLogs.php
+++ b/src/Plugin/AddToDatabaseLogs.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\LogCorrelationId\Plugin;
+
+use Ampersand\LogCorrelationId\Service\CorrelationIdentifier;
+
+class AddToDatabaseLogs
+{
+    /**
+     * @var CorrelationIdentifier
+     */
+    private CorrelationIdentifier $correlationIdentifier;
+
+    /**
+     * Constructor
+     *
+     * @param CorrelationIdentifier $correlationIdentifier
+     */
+    public function __construct(CorrelationIdentifier $correlationIdentifier)
+    {
+        $this->correlationIdentifier = $correlationIdentifier;
+    }
+
+    /**
+     * Append the log correlation ID to the database log
+     *
+     * @param $subject
+     * @param $string
+     * @return string
+     */
+    public function beforeLog($subject, $string)
+    {
+        $logCorrelationIdString =
+            $this->correlationIdentifier->getIdentifierKey() .
+            '=' .
+            $this->correlationIdentifier->getIdentifierValue() .
+            PHP_EOL;
+
+        return $logCorrelationIdString . $string;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -24,6 +24,11 @@
         <plugin name="ampersand_log_correlation_id_response_plugin" type="Ampersand\LogCorrelationId\Plugin\AddToWebApiResponse" sortOrder="1" disabled="false"/>
     </type>
 
+    <!-- Attach X-Log-Correlation-Id to database logs -->
+    <type name="Magento\Framework\DB\LoggerInterface">
+        <plugin name="ampersand_log_correlation_id_db_log_plugin" type="Ampersand\LogCorrelationId\Plugin\AddToDatabaseLogs" sortOrder="1" disabled="false"/>
+    </type>
+
     <!-- Attach amp_correlation_id to all monolog entries -->
     <type name="Magento\Framework\Logger\Monolog">
         <arguments>


### PR DESCRIPTION
1. Added a plugin to add the correlation identifier to all database logs
2. Moved the `Magento\Framework\Logger\Monolog` processor into the `app/etc/*/di.xml` file so that it is configured while the main di is loaded, rather than when the modules are loaded.
3. Test `di:compile`