### PR TITLE
Register shutdown function to set header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ cache:
 
 before_install:
     - if [ ! "$TRAVIS_PULL_REQUEST" = "false" ]; then git branch; git branch -D "$TRAVIS_BRANCH" || true; git checkout -b "$TRAVIS_BRANCH"; fi
-    - phpenv config-rm xdebug.ini || true
     - composer self-update --2
 install:
     - export COMPOSER_MEMORY_LIMIT=-1

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="dev/phpunit-unit-bootstrap.php" backupGlobals="false"
          backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false"
+         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="true"
          stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <testsuites>
         <testsuite name="Ampersand Module Unit Test Suite">

--- a/src/Service/CorrelationIdentifier.php
+++ b/src/Service/CorrelationIdentifier.php
@@ -24,6 +24,7 @@ class CorrelationIdentifier
     {
         Storage::setKey($identifierKey);
         $this->headerInput = $headerInput;
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
         register_shutdown_function([$this, 'shutDownFunction']);
     }
 

--- a/src/Service/CorrelationIdentifier.php
+++ b/src/Service/CorrelationIdentifier.php
@@ -84,10 +84,12 @@ class CorrelationIdentifier
      */
     public function shutDownFunction()
     {
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
         if (headers_sent()) {
             return;
         }
 
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
         $headerAlreadyDefined = array_filter(headers_list(), function ($header) {
             return (stripos($header, Header::X_LOG_CORRELATION_ID) !== false);
         });
@@ -96,6 +98,7 @@ class CorrelationIdentifier
             return;
         }
 
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
         header(Header::X_LOG_CORRELATION_ID . ': ' . $this->getIdentifierValue());
     }
 }

--- a/src/Test/Unit/Service/CorrelationIdentifierTest.php
+++ b/src/Test/Unit/Service/CorrelationIdentifierTest.php
@@ -58,9 +58,6 @@ class CorrelationIdentifierTest extends TestCase
      */
     public function testIdentifierHeaderIsSetOnShutdown()
     {
-        if (headers_sent($filename, $line)) {
-            $this->markTestSkipped("Skipping test as headers are already set on $filename line $line");
-        }
         $httpRequest = $this->createMock(HttpRequest::class);
         $httpRequest->expects($this->any())
             ->method('getHeader')


### PR DESCRIPTION
This was added to catch "Allowed memory size of X bytes exhausted" type errors

This is how the webapi requests handle errors and headers

https://github.com/magento/magento2/blob/7c6b6365a3c099509d6f6e6c306cb1821910aab0/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php#L287-L291

https://github.com/magento/magento2/blob/7c6b6365a3c099509d6f6e6c306cb1821910aab0/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php#L298-L308

https://github.com/magento/magento2/blob/7c6b6365a3c099509d6f6e6c306cb1821910aab0/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php#L221-L237

So a similar approach can be used here to insert the header

Closes #13
