### PR TITLE
Update tests to use `ampersand/magento-docker-test-instance`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
     - composer run test-static-analysis
     - composer run test:unit
     # Install magento
-    - COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ;' CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP
+    - composer run test:integration:install-magento
     # Run integration tests
     - vendor/bin/mtest 'IS_CI_PIPELINE=1 vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug'
     # Output the custom loggers command filtering out modules we've accounted for

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ install:
 script:
     - composer run test-static-analysis
     - composer run test:unit
+    # Configure the additional di.xml
+    - vendor/bin/mtest 'mkdir -p app/etc/ampersand_magento2_log_correlation'
+    - vendor/bin/mtest 'cp /current_extension/app/etc/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/'
     # Install magento
     - CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP
-    # Configure the additional di.xml
-    - vendor/bin/mtest 'mkdir app/etc/ampersand_magento2_log_correlation'
-    - vendor/bin/mtest 'cp /current_extension/app/etc/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/'
     # Configure for integration tests
     - vendor/bin/mtest 'IS_CI_PIPELINE=1 vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug'
     # Output the custom loggers command filtering out modules we've accounted for

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,22 +20,16 @@ script:
     # Install magento
     - composer run test:integration:install-magento
     # Run integration tests
-    - vendor/bin/mtest 'IS_CI_PIPELINE=1 vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug'
+    - vendor/bin/mtest "TEST_GROUP=$TEST_GROUP IS_CI_PIPELINE=1 vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug"
     # Output the custom loggers command filtering out modules we've accounted for
-    - # TODO if [[ $TEST_GROUP = magento_23 ]];     then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" ; fi
-    - # TODO if [[ $TEST_GROUP = magento_latest ]]; then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger" ; fi
-    # Test di compilation
-    - #rm -rf generated
-    - #composer install
-    - #php bin/magento module:enable --all
-    - #php bin/magento setup:di:compile
+    - if [[ $TEST_GROUP = 2-3-7-p2 ]]; then vendor/bin/mtest 'php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger"' ; fi
+    - if [[ $TEST_GROUP = 2-latest ]]; then vendor/bin/mtest 'php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger"' ; fi
+    - false
 
 after_failure:
-  - # TODO
-  - cd ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/
-  - for r in ./var/report/*; do cat $r; done
-  - for l in ./var/log/*;  do cat $l; done
-  - ls -l ./dev/tests/integration/tmp/sandbox*/var
-  - for r in ./dev/tests/integration/tmp/sandbox*/var/report/*; do cat $r; done
-  - for l in ./dev/tests/integration/tmp/sandbox*/var/log/*; do cat $l; done
+  - vendor/bin/mtest 'cat /var/www/html/var/log/*.log'
+  - vendor/bin/mtest 'for r in ./var/report/*; do cat $r; done'
+  - vendor/bin/mtest 'ls -l ./dev/tests/integration/tmp/sandbox*/var'
+  - vendor/bin/mtest 'for r in ./dev/tests/integration/tmp/sandbox*/var/report/*; do cat $r; done'
+  - vendor/bin/mtest 'for l in ./dev/tests/integration/tmp/sandbox*/var/log/*; do cat $l; done'
   - sleep 10;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
     - composer run test-static-analysis
     - composer run test:unit
     # Install magento
-    - COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/app/etc/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ;' CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP
+    - COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ;' CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP
     # Run integration tests
     - vendor/bin/mtest 'IS_CI_PIPELINE=1 vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug'
     # Output the custom loggers command filtering out modules we've accounted for

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,69 +1,40 @@
-language: php
-php:
-    - 7.4
-    - 8.1
-git:
-  depth: false
-dist: xenial
-env:
-    - TEST_GROUP=magento_latest
-    - TEST_GROUP=magento_23
-jobs:
-    exclude:
-        -   php: 8.1
-            env: TEST_GROUP=magento_23
-        -   php: 7.4
-            env: TEST_GROUP=magento_latest
-addons:
-    apt:
-        packages:
-            - postfix
-            - apache2
-            - libapache2-mod-fastcgi
 services:
-    - mysql
-cache:
-    apt: true
-    directories:
-        - $HOME/.composer/cache
-        - $HOME/bin
+  - docker
+
+env:
+  - TEST_GROUP=2-3-7-p2
+  - TEST_GROUP=2-latest
 
 before_install:
-    - if [ ! "$TRAVIS_PULL_REQUEST" = "false" ]; then git branch; git branch -D "$TRAVIS_BRANCH" || true; git checkout -b "$TRAVIS_BRANCH"; fi
-    - composer self-update --2
+  - travis_retry wget https://github.com/docker/compose/releases/download/v2.17.0/docker-compose-linux-x86_64
+  - sudo mv docker-compose-linux-x86_64 /usr/libexec/docker/cli-plugins/docker-compose
+  - sudo chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+  - docker --version && docker compose version
+  - composer self-update --2 && composer self-update --2.2
+
 install:
-    - export COMPOSER_MEMORY_LIMIT=-1
-    - export COMPOSER_PACKAGE_NAME=$(composer config name)
     - composer install --no-interaction
 script:
     - composer run test-static-analysis
     - composer run test:unit
     # Install magento
-    - if [[ $TEST_GROUP = magento_23 ]];     then NAME=ampmodule FULL_INSTALL=0 VERSION=2.3.7-p2    . ./vendor/bin/travis-install-magento.sh; fi
-    - if [[ $TEST_GROUP = magento_latest ]]; then NAME=ampmodule FULL_INSTALL=0                     . ./vendor/bin/travis-install-magento.sh; fi
-    # Install this module
-    - cd vendor/ampersand/travis-vanilla-magento/instances/ampmodule
-    - composer config repo.ampmodule git "$TRAVIS_BUILD_DIR"
-    - composer require -vvv "$COMPOSER_PACKAGE_NAME:dev-$TRAVIS_BRANCH" || composer require -vvv "$COMPOSER_PACKAGE_NAME:$TRAVIS_BRANCH"
+    - CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP
     # Configure the additional di.xml
-    - mkdir -p $TRAVIS_BUILD_DIR/vendor/ampersand/travis-vanilla-magento/instances/ampmodule/app/etc/ampersand_magento2_log_correlation/
-    - cp $TRAVIS_BUILD_DIR/dev/ampersand_magento2_log_correlation/di.xml $TRAVIS_BUILD_DIR/vendor/ampersand/travis-vanilla-magento/instances/ampmodule/app/etc/ampersand_magento2_log_correlation/
+    - vendor/bin/mtest 'mkdir app/etc/ampersand_magento2_log_correlation'
+    - vendor/bin/mtest 'cp /current_extension/app/etc/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/'
     # Configure for integration tests
-    - mysql -uroot -e 'SET @@global.sql_mode = NO_ENGINE_SUBSTITUTION; DROP DATABASE IF EXISTS magento_integration_tests; CREATE DATABASE magento_integration_tests;'
-    - cp dev/tests/integration/etc/install-config-mysql.travis-no-rabbitmq.php.dist dev/tests/integration/etc/install-config-mysql.php
-    - php $TRAVIS_BUILD_DIR/dev/prepare_phpunit_config.php $TRAVIS_BUILD_DIR/vendor/ampersand/travis-vanilla-magento/instances/ampmodule
-    - composer install -o
-    - IS_CI_PIPELINE=1 vendor/bin/phpunit -c $(pwd)/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug
+    - vendor/bin/mtest 'IS_CI_PIPELINE=1 vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug'
     # Output the custom loggers command filtering out modules we've accounted for
-    - if [[ $TEST_GROUP = magento_23 ]];     then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" ; fi
-    - if [[ $TEST_GROUP = magento_latest ]]; then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger" ; fi
+    - # TODO if [[ $TEST_GROUP = magento_23 ]];     then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" ; fi
+    - # TODO if [[ $TEST_GROUP = magento_latest ]]; then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger" ; fi
     # Test di compilation
-    - rm -rf generated
-    - composer install
-    - php bin/magento module:enable --all
-    - php bin/magento setup:di:compile
+    - #rm -rf generated
+    - #composer install
+    - #php bin/magento module:enable --all
+    - #php bin/magento setup:di:compile
 
 after_failure:
+  - # TODO
   - cd ./vendor/ampersand/travis-vanilla-magento/instances/ampmodule/
   - for r in ./var/report/*; do cat $r; done
   - for l in ./var/log/*;  do cat $l; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ script:
     # Output the custom loggers command filtering out modules we've accounted for
     - if [[ $TEST_GROUP = 2-3-7-p2 ]]; then vendor/bin/mtest 'php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger"' ; fi
     - if [[ $TEST_GROUP = 2-latest ]]; then vendor/bin/mtest 'php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Yotpo\Yotpo\Model\Logger" --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" --filter "Magento\AdminAdobeIms\Logger\AdminAdobeImsLogger"' ; fi
-    - false
 
 after_failure:
   - vendor/bin/mtest 'cat /var/www/html/var/log/*.log'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,9 @@ install:
 script:
     - composer run test-static-analysis
     - composer run test:unit
-    # Configure the additional di.xml
-    - vendor/bin/mtest 'mkdir -p app/etc/ampersand_magento2_log_correlation'
-    - vendor/bin/mtest 'cp /current_extension/app/etc/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/'
     # Install magento
-    - CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP
-    # Configure for integration tests
+    - COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/app/etc/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ;' CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP
+    # Run integration tests
     - vendor/bin/mtest 'IS_CI_PIPELINE=1 vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug'
     # Output the custom loggers command filtering out modules we've accounted for
     - # TODO if [[ $TEST_GROUP = magento_23 ]];     then php bin/magento ampersand:log-correlation-id:list-custom-loggers --filter "Klarna\Core\Logger\Logger" --filter "Dotdigitalgroup\Email\Logger\Logger" --filter "Amazon\Core\Logger\Logger" --filter "Amazon\Core\Logger\IpnLogger" ; fi

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
             "@test:unit"
         ],
         "test:integration:install-magento": [
-            "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ; ' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP",
-            "composer dump-autoload --optimize ;"
+            "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ; composer install -o ;' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP",
+            "composer install -o ;"
         ]
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         ]
     },
     "require-dev": {
-        "ampersand/travis-vanilla-magento": "^1.1",
+        "ampersand/magento-docker-test-instance": "^0.1",
         "bitexpert/phpstan-magento": "^0.11",
         "friendsofphp/php-cs-fixer": "^3.4",
         "magento/magento-coding-standard": "^15",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "test": [
             "@test-static-analysis",
             "@test:unit"
-        ]
+        ],
+        "test:integration:install-magento": "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ; composer dump-autoload --optimize ;' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP"
     },
     "require-dev": {
         "ampersand/magento-docker-test-instance": "^0.1",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,10 @@
             "@test-static-analysis",
             "@test:unit"
         ],
-        "test:integration:install-magento": "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ; composer dump-autoload --optimize ;' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP"
+        "test:integration:install-magento": [
+            "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ; ' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP",
+            "composer dump-autoload --optimize ;"
+        ]
     },
     "require-dev": {
         "ampersand/magento-docker-test-instance": "^0.1",

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,7 @@
             "@test:unit"
         ],
         "test:integration:install-magento": [
-            "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ; composer install -o ;' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP",
-            "composer install -o ;"
+            "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ; composer dump-autoload --optimize ;' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP"
         ]
     },
     "require-dev": {

--- a/src/Test/Integration/ListCustomLoggersCommandTest.php
+++ b/src/Test/Integration/ListCustomLoggersCommandTest.php
@@ -29,7 +29,7 @@ class ListCustomLoggersCommandTest extends TestCase
         $tester = new CommandTester($this->objectManager->create(ListCustomLoggersCommand::class));
         $this->assertEquals(0, $tester->execute([]));
 
-        if (getenv('TEST_GROUP') === 'magento_latest') {
+        if (getenv('TEST_GROUP') === '2-latest') {
             return; // Magento 2.4.4 has removed a lot of third party bundled modules
         }
 


### PR DESCRIPTION
Remove https://github.com/AmpersandHQ/travis-vanilla-magento in favour of https://github.com/AmpersandHQ/magento-docker-test-instance

This fixes the odd error on the current main branch on the latest version of magento
https://app.travis-ci.com/github/AmpersandHQ/magento2-log-correlation-id/builds/262258971
```
In PluginManager.php(274) : eval()'d code line 248:
                                                                               
  [Exception]                                                                  
  Higher matching version dev-main 6025788 of ampersand/magento2-log-correlat  
  ion-id was found in public repository packagist.org                          
                               than v1.3.1 in private . Public package might'  
  ve been taken over by a malicious entity,                                    
                               please investigate and update package requirem  
  ent to match the version from the private repository                                                                                                  
```

This also makes running the test locally much more convenient
```
composer install
composer run test:integration:install-magento
vendor/bin/mtest "vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug"
```