### PR TITLE
Capturing correlation IDs against CLI processes and DB queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ services:
 
 env:
   - TEST_GROUP=2-3-7-p2
+  - TEST_GROUP=2-4-0
+  - TEST_GROUP=2-4-1
+  - TEST_GROUP=2-4-2
+  - TEST_GROUP=2-4-3
+  - TEST_GROUP=2-4-4
+  - TEST_GROUP=2-4-5
+  - TEST_GROUP=2-4-6
   - TEST_GROUP=2-latest
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ If the request was long-running, or had an error it may also be flagged in new r
 
 Inside `app/etc/ampersand_magento2_log_correlation/di.xml`  you can change to `disabled="false"`
 
-```xml
-    <type name="Magento\Framework\App\ResourceConnection">
-    <plugin name="ampersand_log_correlation_id_db_query_plugin" disabled="false" />
-</type>
+```diff
+  <type name="Magento\Framework\App\ResourceConnection">
+-     <plugin name="ampersand_log_correlation_id_db_query_plugin" disabled="true" />
++     <plugin name="ampersand_log_correlation_id_db_query_plugin" disabled="false" />
+  </type>
 ```
 
 This will add the correlation identifier to all queries like `SELECT store_group.* FROM store_group /* 'cid-652918943af7b811319570' */ `

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Run module installation
 php bin/magento setup:upgrade
 ```
 
+# todo enable mysql query correlation ids
+
 ## Uninstall
 
 ```bash
@@ -53,6 +55,7 @@ This cache decorator initialises the identifier which is immutable for the remai
 - Monolog files have the correlation ID added into their context section under the key `amp_correlation_id` via `src/Processor/MonologCorrelationId.php`
 - Magento database logs have this identifier added by `src/Plugin/AddToDatabaseLogs.php`
 - New Relic has this added as a custom parameter under the key `amp_correlation_id`
+- TODO mysql and CLI
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ mkdir app/etc/ampersand_magento2_log_correlation
 cp vendor/ampersand/magento2-log-correlation-id/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/
 ```
 
+At this point you can make any configuration changes
+- [Add identifier to MySQL queries (disabled by default)](#add-identifier-to-mysql-queries)
+- [Change the key name from `amp_correlation_id`](#change-the-key-name-from-amp_correlation_id)
+- [Use existing correlation id from request header](#use-existing-correlation-id-from-request-header)
+
 Run module installation
 ```bash
 php bin/magento setup:upgrade
 ```
-
-# todo enable mysql query correlation ids
 
 ## Uninstall
 
@@ -55,7 +58,8 @@ This cache decorator initialises the identifier which is immutable for the remai
 - Monolog files have the correlation ID added into their context section under the key `amp_correlation_id` via `src/Processor/MonologCorrelationId.php`
 - Magento database logs have this identifier added by `src/Plugin/AddToDatabaseLogs.php`
 - New Relic has this added as a custom parameter under the key `amp_correlation_id`
-- TODO mysql and CLI
+- CLI processes have it added as their "title" by using `cli_set_process_title` via `Ampersand\LogCorrelationId\CacheDecorator\CorrelationIdDecorator::setCliProcessTitle`
+- MySQL queries have it added as a comment at the end of the query via `Ampersand\LogCorrelationId\Plugin\AddToDatabaseQueries::afterGetConnection`
 
 ## Example usage
 
@@ -89,6 +93,18 @@ $ grep -ri 61e04d741bf78 ./var/log
 If the request was long-running, or had an error it may also be flagged in new relic with the custom parameter `amp_correlation_id`
  
 ## Configuration and Customisation
+
+### Add identifier to MySQL queries 
+
+Inside `app/etc/ampersand_magento2_log_correlation/di.xml`  you can change to `disabled="false"`
+
+```xml
+    <type name="Magento\Framework\App\ResourceConnection">
+    <plugin name="ampersand_log_correlation_id_db_query_plugin" disabled="false" />
+</type>
+```
+
+This will add the correlation identifier to all queries like `SELECT store_group.* FROM store_group /* 'cid-652918943af7b811319570' */ `
 
 ### Change the key name from `amp_correlation_id`
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "magento/*": true
-        }
+        },
+        "process-timeout": 1200
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
             "@test:unit"
         ],
         "test:integration:install-magento": [
-            "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di.xml app/etc/ampersand_magento2_log_correlation/ ; composer dump-autoload --optimize ;' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP"
+            "COMPOSER_AFTER_INSTALL_COMMAND='mkdir -p app/etc/ampersand_magento2_log_correlation; cp /current_extension/dev/ampersand_magento2_log_correlation/di_integration_test_suite.xml app/etc/ampersand_magento2_log_correlation/di.xml ; composer dump-autoload --optimize ;' CURRENT_EXTENSION=\".\" vendor/bin/mtest-make $TEST_GROUP"
         ]
     },
     "require-dev": {

--- a/dev/ampersand_magento2_log_correlation/di_integration_test_suite.xml
+++ b/dev/ampersand_magento2_log_correlation/di_integration_test_suite.xml
@@ -41,6 +41,6 @@
 
     <!-- Make this plugin disabled by default, full definition inside the module etc/di.xml-->
     <type name="Magento\Framework\App\ResourceConnection">
-        <plugin name="ampersand_log_correlation_id_db_query_plugin" disabled="true" />
+        <plugin name="ampersand_log_correlation_id_db_query_plugin" disabled="false" />
     </type>
 </config>

--- a/src/CacheDecorator/CorrelationIdDecorator.php
+++ b/src/CacheDecorator/CorrelationIdDecorator.php
@@ -48,5 +48,34 @@ class CorrelationIdDecorator extends Bare
                 $correlationIdentifier->getIdentifierValue()
             );
         }
+
+        // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+        @$this->setCliProcessTitle($correlationIdentifier);
+    }
+
+    /**
+     * Set the CLI process title, where possible depending on OS
+     *
+     * @param CorrelationIdentifier $correlationIdentifier
+     * @link https://github.com/php/php-src/issues/11246
+     * @return void
+     */
+    private function setCliProcessTitle(CorrelationIdentifier $correlationIdentifier)
+    {
+        try {
+            if (php_sapi_name() !== 'cli') {
+                return;
+            }
+            $processTitle = cli_get_process_title();
+            if (!is_string($processTitle)) {
+                return;
+            }
+            if (stripos($processTitle, $correlationIdentifier->getIdentifierValue()) !== false) {
+                return;
+            }
+            cli_set_process_title($processTitle . ' ' . $correlationIdentifier->getIdentifierValue());
+            // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock.DetectedCatch
+        } catch (\Throwable $throwable) {
+        }
     }
 }

--- a/src/CacheDecorator/CorrelationIdDecorator.php
+++ b/src/CacheDecorator/CorrelationIdDecorator.php
@@ -49,19 +49,26 @@ class CorrelationIdDecorator extends Bare
             );
         }
 
+        /*
+         * The support for cli_get_process_title and cli_set_process_title is not great everywhere, so if this fails
+         * just do it quietly, otherwise it will break the entire application and log a lot of problems
+         */
         // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-        @$this->setCliProcessTitle($correlationIdentifier);
+        @$this->setCliProcessTitle($correlationIdentifier, $request);
     }
 
     /**
      * Set the CLI process title, where possible depending on OS
      *
      * @param CorrelationIdentifier $correlationIdentifier
+     * @param HttpRequest $request
      * @link https://github.com/php/php-src/issues/11246
      * @return void
      */
-    private function setCliProcessTitle(CorrelationIdentifier $correlationIdentifier)
-    {
+    private function setCliProcessTitle(
+        CorrelationIdentifier $correlationIdentifier,
+        HttpRequest $request
+    ) {
         try {
             if (php_sapi_name() !== 'cli') {
                 return;
@@ -70,10 +77,18 @@ class CorrelationIdDecorator extends Bare
             if (!is_string($processTitle)) {
                 return;
             }
+            if (!strlen($processTitle)) {
+                /** @var array<string> $argv */
+                $argv = $request->getServer('argv', []);
+                /**
+                 * @see https://github.com/magento/magento2/blob/2b3ad2eeb6903643b678ceeb7d1ea7361035dee7/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php#L973C43-L973C62
+                 */
+                $processTitle = PHP_BINARY . ' ' . implode(' ', $argv);
+            }
             if (stripos($processTitle, $correlationIdentifier->getIdentifierValue()) !== false) {
                 return;
             }
-            cli_set_process_title($processTitle . ' ' . $correlationIdentifier->getIdentifierValue());
+            cli_set_process_title($processTitle . ' (' . $correlationIdentifier->getIdentifierValue() . ') ');
             // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock.DetectedCatch
         } catch (\Throwable $throwable) {
         }

--- a/src/MysqlQueryHook/AddToDatabaseQueries.php
+++ b/src/MysqlQueryHook/AddToDatabaseQueries.php
@@ -61,7 +61,7 @@ class AddToDatabaseQueries
         }
 
         $identifier = $this->correlationIdentifier->getIdentifierValue();
-        if (!strlen($identifier)) {
+        if (strlen($identifier) <= 0 || strlen($identifier) >= 128) {
             return;
         }
 
@@ -74,17 +74,16 @@ class AddToDatabaseQueries
          * 2. Escape meta chars (inside quoteInto it calls addcslashes)
          * 3. Escape the value by putting in single quotes (part of quoteInto)
          */
-        $identifier = $this->adapter->quoteInto(
-            ' /* ? */ ',
-            str_replace('%', '%%', rawurlencode($identifier))
-        );
+        $identifier = str_replace('%', '%%', rawurlencode($identifier));
+        if (!preg_match('/^[a-zA-Z0-9_.~%-]*$/', $identifier)) {
+            return;
+        }
 
+        $identifier = $this->adapter->quoteInto(' /* ? */ ', $identifier);
         if (strpos($sql, $identifier) !== false) {
             return; // double check we've not already added it
         }
 
-        if (strlen($identifier) <= 128 && preg_match('/^[a-zA-Z0-9_.~-]*$/', $identifier)) {
-            $sql .= $identifier;
-        }
+        $sql .= $identifier;
     }
 }

--- a/src/MysqlQueryHook/AddToDatabaseQueries.php
+++ b/src/MysqlQueryHook/AddToDatabaseQueries.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\LogCorrelationId\MysqlQueryHook;
+
+use Ampersand\LogCorrelationId\Service\CorrelationIdentifier;
+use Magento\Framework\DB\Adapter\Pdo\Mysql;
+
+class AddToDatabaseQueries
+{
+    /**
+     * @var CorrelationIdentifier
+     */
+    private CorrelationIdentifier $correlationIdentifier;
+
+    /**
+     * @var Mysql
+     */
+    private Mysql $adapter;
+
+    /**
+     * @param CorrelationIdentifier $correlationIdentifier
+     */
+    public function __construct(
+        CorrelationIdentifier $correlationIdentifier
+    ) {
+        $this->correlationIdentifier = $correlationIdentifier;
+    }
+
+    /**
+     * Set the correlation ID for this query
+     *
+     * @param Mysql $adapter
+     * @return void
+     */
+    public function setMysqlAdapter(Mysql $adapter)
+    {
+        if (isset($this->adapter) && $this->adapter instanceof Mysql) {
+            return;
+        }
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Attach the correlation id to database queries
+     *
+     * @see \Magento\Framework\DB\Adapter\Pdo\Mysql::_prepareQuery()
+     * @param \Magento\Framework\DB\Select|string $sql
+     * @param mixed $bind
+     * @return void
+     */
+    public function addToDatabaseQueries(&$sql, &$bind = [])
+    {
+        if (!is_string($sql)) {
+            return;
+        }
+        if (!strlen($sql)) {
+            return;
+        }
+        if (strpos($sql, $this->correlationIdentifier->getIdentifierValue()) !== false) {
+            return; // double check we've not already added it
+        }
+        if (!(isset($this->adapter) && $this->adapter instanceof Mysql)) {
+            return;
+        }
+        //TODO make sure this is not vulnerable to SQL injection as it gets concatenated at the end of the query
+        $sql .= $this->adapter->quoteInto(' /* ? */ ', $this->correlationIdentifier->getIdentifierValue());
+    }
+}

--- a/src/MysqlQueryHook/AddToDatabaseQueries.php
+++ b/src/MysqlQueryHook/AddToDatabaseQueries.php
@@ -75,6 +75,18 @@ class AddToDatabaseQueries
          * 3. Escape the value by putting in single quotes (part of quoteInto)
          */
         $identifier = str_replace('%', '%%', rawurlencode($identifier));
+        /**
+         * An additional paranoid check to remove all multiple concurrent usages of a hyphen
+         * This is a comment format in MySQL
+         *
+         * The other format of comment / * Like this * / is handled by the rawurlencode and will be like %2A%2F
+         *
+         * With both these changes, breaking out from the hardcoded comment below should not be possible.
+         */
+        $identifier = preg_replace('/-+/', '-', $identifier);
+        if (!is_string($identifier)) {
+            return;
+        }
         if (!preg_match('/^[a-zA-Z0-9_.~%-]*$/', $identifier)) {
             return;
         }

--- a/src/Plugin/AddToDatabaseQueries.php
+++ b/src/Plugin/AddToDatabaseQueries.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\LogCorrelationId\Plugin;
+
+use Ampersand\LogCorrelationId\MysqlQueryHook;
+use Magento\Framework\App\ResourceConnection;
+
+class AddToDatabaseQueries
+{
+    /**
+     * @var MysqlQueryHook\AddToDatabaseQueries
+     */
+    private MysqlQueryHook\AddToDatabaseQueries $addToDatabaseQueries;
+
+    /**
+     * @param MysqlQueryHook\AddToDatabaseQueries $addToDatabaseQueries
+     */
+    public function __construct(
+        MysqlQueryHook\AddToDatabaseQueries $addToDatabaseQueries
+    ) {
+        $this->addToDatabaseQueries = $addToDatabaseQueries;
+    }
+
+    /**
+     * Attach the correlation ID to database queries after the connection is gathered
+     *
+     * @param ResourceConnection $subject
+     * @param \Magento\Framework\DB\Adapter\Pdo\Mysql|mixed $result
+     * @return \Magento\Framework\DB\Adapter\Pdo\Mysql|mixed
+     */
+    public function afterGetConnection(ResourceConnection $subject, $result)
+    {
+        if ($result instanceof \Magento\Framework\DB\Adapter\Pdo\Mysql) {
+            $this->addToDatabaseQueries->setMysqlAdapter($result);
+            $result->setQueryHook(
+                [
+                    'object' => $this->addToDatabaseQueries,
+                    'method' => 'addToDatabaseQueries'
+                ]
+            );
+        }
+        return $result;
+    }
+}

--- a/src/Test/Integration/DatabaseQueryTest.php
+++ b/src/Test/Integration/DatabaseQueryTest.php
@@ -74,6 +74,7 @@ class DatabaseQueryTest extends TestCase
         $identifier = Bootstrap::getObjectManager()->get(CorrelationIdentifier::class)->getIdentifierValue();
 
         $line = $this->getLineFromLog($query);
+        $this->assertStringContainsString('cid-', $identifier, 'the test is not a basic cid');
         $this->assertStringContainsString($query, $line);
         $this->assertStringContainsString(" /* '$identifier' */ ", $line);
         $this->setDatabaseLoggingAlias('disabled');

--- a/src/Test/Integration/DatabaseQueryTest.php
+++ b/src/Test/Integration/DatabaseQueryTest.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types=1);
+
+namespace Ampersand\LogCorrelationId\Test\Integration;
+
+use Ampersand\LogCorrelationId\Service\CorrelationIdentifier;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Logger\Handler\System as SystemLogHandler;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class DatabaseQueryTest extends TestCase
+{
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var \Magento\Framework\DB\Adapter\AdapterInterface  */
+    private $connection;
+
+    /** @var ResourceConnection  */
+    private $resourceConnection;
+
+    /** @var string */
+    private $logDir = '';
+
+    /**
+     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\RuntimeException
+     */
+    protected function setUp(): void
+    {
+        /** @var \Magento\TestFramework\ObjectManager $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+
+        $this->resourceConnection = Bootstrap::getObjectManager()->get(ResourceConnection::class);
+        $this->connection = $this->resourceConnection->getConnection();
+        $this->logger = $objectManager->get(LoggerInterface::class);
+        $this->logger->info('ensure something is written for the dir to exist');
+
+        foreach ($this->logger->getHandlers() as $handler) {
+            if ($handler instanceof SystemLogHandler) {
+                $this->logDir = dirname($handler->getUrl());
+                break;
+            }
+        }
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws \Magento\Framework\Exception\RuntimeException
+     * @throws \ReflectionException
+     */
+    protected function tearDown(): void
+    {
+        $this->setDatabaseLoggingAlias('disabled');
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testDatabaseLogsContainCorrelationId()
+    {
+        if (!getenv('IS_CI_PIPELINE')) {
+            $this->markTestSkipped('Skipping this test as it is not in the modules CI pipeline');
+        }
+
+        $this->setDatabaseLoggingAlias('file');
+
+        $query = 'select ' . time();
+        $this->resourceConnection->getConnection()->query($query);
+
+        $identifier = Bootstrap::getObjectManager()->get(CorrelationIdentifier::class)->getIdentifierValue();
+
+        $line = $this->getLineFromLog($query);
+        $this->assertStringContainsString($query, $line);
+        $this->assertStringContainsString(" /* '$identifier' */ ", $line);
+        $this->setDatabaseLoggingAlias('disabled');
+    }
+
+    /**
+     * @param $logMessage
+     * @return mixed|null
+     */
+    private function getLineFromLog($logMessage)
+    {
+        $contents = $this->getLogFileContents('db.log');
+        $this->assertStringContainsString($logMessage, $contents, 'Log file does not contain message');
+
+        // Get the line containing this unique message
+        $contents = array_filter(
+            explode(PHP_EOL, $contents),
+            function ($line) use ($logMessage) {
+                return strpos($line, $logMessage) !== false;
+            }
+        );
+
+        $this->assertCount(1, $contents, 'We should only a unique entry with this log message');
+        $line = array_pop($contents);
+        return $line;
+    }
+
+    /**
+     * @param $logfile
+     * @return false|string
+     */
+    private function getLogFileContents($logfile)
+    {
+        $logFile = $this->getLogFilePath($logfile);
+        if (is_file($logFile)) {
+            $this->assertFileExists($logFile, ' log file does not exist');
+            clearstatcache(true, $logFile);
+            $contents = \file_get_contents($logFile);
+            return $contents;
+        }
+        return "$logFile does not exist" . PHP_EOL;
+    }
+
+    /**
+     * @param $logfile
+     * @return string
+     */
+    private function getLogFilePath($logfile)
+    {
+        return rtrim($this->logDir, DIRECTORY_SEPARATOR) . '/../debug/' . $logfile;
+    }
+
+    /**
+     * The database logger is so low level it would have to reboot the integration tests from scratch
+     *
+     * Work around it by toggling on the database logger using reflection
+     *
+     * @param string $alias
+     * @throws \ReflectionException
+     */
+    private function setDatabaseLoggingAlias($alias)
+    {
+        $connectionReflection = new \ReflectionObject($this->connection);
+        $loggerReflection = $connectionReflection->getProperty('logger');
+        $loggerReflection->setAccessible(true);
+
+        $databaseLogger = $loggerReflection->getValue($this->connection);
+        $databaseLoggerReflection = new \ReflectionObject($databaseLogger);
+
+        $loggerProperty = $aliasProperty = null;
+
+        // Navigate parents classes to get appropriate properties
+        // We have the ampersand module extending the core, but plugins can put a third layer of interception on this
+        for ($i=0; $i<5; $i++) {
+            $props = $databaseLoggerReflection->getProperties();
+            foreach ($props as $prop) {
+                if (!$aliasProperty && $prop->getName() === 'loggerAlias') {
+                    $prop->setAccessible(true);
+                    $aliasProperty = $prop;
+                }
+                if (!$loggerProperty && $prop->getName() === 'logger') {
+                    $prop->setAccessible(true);
+                    $loggerProperty = $prop;
+                }
+            }
+            if (isset($loggerProperty, $aliasProperty)) {
+                break;
+            }
+            $databaseLoggerReflection = $databaseLoggerReflection->getParentClass();
+        }
+
+        if (!isset($loggerProperty, $aliasProperty)) {
+            $this->fail('Could not get reflection properties');
+        }
+
+        $loggerProperty->setValue($databaseLogger, null); // to ensure lazy load picks it up and regenerates
+        $aliasProperty->setValue($databaseLogger, $alias);
+    }
+}

--- a/src/Test/Integration/ListCustomLoggersCommandTest.php
+++ b/src/Test/Integration/ListCustomLoggersCommandTest.php
@@ -29,8 +29,8 @@ class ListCustomLoggersCommandTest extends TestCase
         $tester = new CommandTester($this->objectManager->create(ListCustomLoggersCommand::class));
         $this->assertEquals(0, $tester->execute([]));
 
-        if (getenv('TEST_GROUP') === '2-latest') {
-            return; // Magento 2.4.4 has removed a lot of third party bundled modules
+        if (in_array(getenv('TEST_GROUP'), ['2-latest', '2-4-6', '2-4-5', '2-4-4', '2-4-3'], true)) {
+            return;
         }
 
         /*

--- a/src/Test/Integration/ProcessTitleTest.php
+++ b/src/Test/Integration/ProcessTitleTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Ampersand\LogCorrelationId\Test\Integration;
+
+use Ampersand\LogCorrelationId\Service\CorrelationIdentifier;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class ProcessTitleTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testProcessTitleHasCorrelationId()
+    {
+        if (!getenv('IS_CI_PIPELINE')) {
+            $this->markTestSkipped('Skipping this test as it is not in the modules CI pipeline');
+        }
+
+        cli_set_process_title('');
+        $this->assertEquals('', cli_get_process_title(), 'The process title should start empty');
+
+        /*
+         * These tests need to reinialize the app so that the cache decorator can be redone from scratch
+         */
+        Bootstrap::getInstance()->reinitialize();
+
+        $identifier = Bootstrap::getObjectManager()->get(CorrelationIdentifier::class)->getIdentifierValue();
+
+        $this->assertStringContainsString(
+            "($identifier)",
+            cli_get_process_title(),
+            'The cli process title did not contain the identifier'
+        );
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -29,6 +29,11 @@
         <plugin name="ampersand_log_correlation_id_db_log_plugin" type="Ampersand\LogCorrelationId\Plugin\AddToDatabaseLogs" sortOrder="1" disabled="false"/>
     </type>
 
+    <!-- Attach log correlation id to database queries as a comment -->
+    <type name="Magento\Framework\App\ResourceConnection">
+        <plugin name="ampersand_log_correlation_id_db_query_plugin" type="Ampersand\LogCorrelationId\Plugin\AddToDatabaseQueries" sortOrder="99" disabled="false"/>
+    </type>
+
     <!-- Attach amp_correlation_id to all monolog entries -->
     <type name="Magento\Framework\Logger\Monolog">
         <arguments>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -30,7 +30,6 @@
     </type>
 
     <!-- Attach log correlation id to database queries as a comment -->
-    <!-- TODO Make this disabled by default -->
     <type name="Magento\Framework\App\ResourceConnection">
         <plugin name="ampersand_log_correlation_id_db_query_plugin" type="Ampersand\LogCorrelationId\Plugin\AddToDatabaseQueries" sortOrder="99" />
     </type>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -30,8 +30,9 @@
     </type>
 
     <!-- Attach log correlation id to database queries as a comment -->
+    <!-- TODO Make this disabled by default -->
     <type name="Magento\Framework\App\ResourceConnection">
-        <plugin name="ampersand_log_correlation_id_db_query_plugin" type="Ampersand\LogCorrelationId\Plugin\AddToDatabaseQueries" sortOrder="99" disabled="false"/>
+        <plugin name="ampersand_log_correlation_id_db_query_plugin" type="Ampersand\LogCorrelationId\Plugin\AddToDatabaseQueries" sortOrder="99" />
     </type>
 
     <!-- Attach amp_correlation_id to all monolog entries -->


### PR DESCRIPTION
If you've ever seen a long running indexer process and thought "is this actually still doing something or is it stuck" this one should help you

## Adding to process title

Running a command like so, or any `bin/magento` command
```bash
$ magerun db:query 'select sleep(99)'
```

Will set the process title
```bash
$ ps aux | grep magerun | grep -v grep
luker+ 18675  6.6  6.5 592168 249212 pts/0   S+   14:36   0:00 /usr/bin/php /usr/local/bin/magerun db:query select sleep(99) (cid-652d4a61699d4)
```

Being able to see `magerun db:query select sleep(99) (cid-652d4a61699d4)` will allow you to trace from a CLI process to the logs and queries produced by it.

## Adding to SQL queries
The following script yielded the following queries

```php
<?php
use Magento\Framework\App\Bootstrap;
require __DIR__ . '/app/bootstrap.php';

$bootstrap = Bootstrap::create(BP, $_SERVER);
$obj = $bootstrap->getObjectManager();

set_error_handler(function ($severity, $message, $file, $line) {
    throw new \ErrorException($message, $severity, $severity, $file, $line);
});

$state = $obj->get(Magento\Framework\App\State::class);
$state->setAreaCode('frontend');
$obj->get(\Magento\Store\Model\App\Emulation::class)->startEnvironmentEmulation(0, 'adminhtml');

$connection = \Magento\Framework\App\ObjectManager::getInstance()
                    ->get(\Magento\Framework\App\ResourceConnection::class)
                    ->getConnection();

$connection->query('select sleep(5);');
echo "done" . PHP_EOL;
```


```
$ grep SQL var/debug/db.log 
SQL: SET NAMES utf8 /* 'cid-652918943af7b811319570' */ 
SQL: SELECT `store_website`.* FROM `store_website` /* 'cid-652918943af7b811319570' */ 
SQL: SELECT `store_group`.* FROM `store_group` /* 'cid-652918943af7b811319570' */ 
SQL: SELECT `store`.* FROM `store` /* 'cid-652918943af7b811319570' */ 
SQL: select sleep(5); /* 'cid-652918943af7b811319570' */ 
```

## Security concerns

We need to be careful as we're concatenating SQL queries.

It is possible that the correlation value comes from an upstream header https://github.com/AmpersandHQ/magento2-log-correlation-id#use-existing-correlation-id-from-request-header

I want to make sure we aren't leaving ourselves open to SQLi like

```
curl  -H 'X-Trace-Header-Here: select sleep(1)' https://your-magento-site.example.com/ 
```

I have implemented `Ampersand\LogCorrelationId\MysqlQueryHook\AddToDatabaseQueries::addToDatabaseQueries`  as per the [google](https://github.com/google/sqlcommenter) spec (see inline comments).