### PR TITLE
Magento 2.4.8 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.3.0",
-        "magento/framework": "*"
+        "magento/framework": "*",
+        "monolog/monolog": "^3.6"
     },
     "autoload": {
         "files": [

--- a/src/Processor/MonologCorrelationId.php
+++ b/src/Processor/MonologCorrelationId.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace Ampersand\LogCorrelationId\Processor;
 
 use Ampersand\LogCorrelationId\Service\CorrelationIdentifier;
+use Monolog\LogRecord;
 
 class MonologCorrelationId
 {
@@ -25,15 +26,12 @@ class MonologCorrelationId
      * Add the log correlation ID as a piece of context
      *
      * @see \Monolog\Logger::addRecord
-     * @param array<mixed> $record
+     * @param LogRecord $record
      * @return mixed[]
      */
-    public function addCorrelationId(array $record): array
+    public function addCorrelationId(LogRecord $record): LogRecord
     {
-        $key = $this->correlationIdentifier->getIdentifierKey();
-        if (isset($record['context']) && is_array($record['context']) && !isset($record['context'][$key])) {
-            $record['context'] = [$key => $this->correlationIdentifier->getIdentifierValue()] + $record['context'];
-        }
+        $record->extra[$this->correlationIdentifier->getIdentifierKey()] = $this->correlationIdentifier->getIdentifierValue();
         return $record;
     }
 }


### PR DESCRIPTION
- New monolog version is present in 2.4.8
    - https://github.com/Seldaek/monolog/blob/main/UPGRADE.md#300
    -  > Log records have been converted from an array to a [Monolog\LogRecord object](https://github.com/Seldaek/monolog/blob/main/src/Monolog/LogRecord.php) with public (and mostly readonly) properties
- This will move the CID from the "context" section to the "extra" section

Before
```
[2025-03-10T17:52:51.164895+00:00] report.INFO: message {"amp_correlation_id":"cid-67cf26ed6eb98095632707"} []
```

After
```
[2025-03-10T17:52:51.164895+00:00] report.INFO: message [] {"amp_correlation_id":"cid-67cf26ed6eb98095632707"}
```

I have also put a requirement for monolog `^3.6` into the composer.json to stop this newer version being installed on `<=2.4.8` versions. Those versions wont accept the 3.x series and will install the old tags.